### PR TITLE
Stripping BOM to make it Windows compatible

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -25,6 +25,7 @@ function loadHTTP(uri, options, callback) {
 
 function loadPath(src, options, callback) {
 	fs.readFile(src, 'utf8', function (err, str) {
+		str = str.replace(/^\uFEFF/, ''); // Strip BOM if it exist
 		if (err) {
 			return callback(err);
 		}


### PR DESCRIPTION
Be default, most Windows text editors saves files in UTF-8 encoding with a signature (BOM). The async `fs.readFile` method in Node.js doesn't strip the BOM automatically, which makes most files invalid. In the case of TV4, all `.json` files are unreadable on Windows because of this issue.

The official workaround is to strip the BOM like I did in this PR.
