### PR TITLE
Set banUnknown to false

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -90,7 +90,7 @@ function getOptions(merge) {
 		multi: false,
 		timeout: 5000,
 		checkRecursive: false,
-		banUnknown: true,
+		banUnknown: false,
 		languages: {},
 		language: null
 	};


### PR DESCRIPTION
This conforms with JSON Schema v4 that specifies that `additionalProperties` must be `true` if not otherwise specified
