### PR TITLE
Greenkeeper/eslint plugin node 4.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "eslint-plugin-jsdoc": "^2.3.1",
-    "eslint-plugin-node": "~4.1.0",
+    "eslint-plugin-node": "~4.2.1",
     "grunt": "^1.0.1",
     "grunt-continue": "^0.1.0",
     "grunt-contrib-connect": "~1.0.2",


### PR DESCRIPTION
- chore(package): update eslint-plugin-node to version 4.2.1
- Closes #25
- https://greenkeeper.io/