### PR TITLE
Node 14 test runs

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 19.x]
+        node-version: [14.0.x, 14.13.x, 14.17.x, 14.x, 16.x, 18.x, 19.x]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
- Split out nodejs 14.0.x, 14.13.x, 14.17.x and 14.x test runs